### PR TITLE
Update feerci.pyx

### DIFF
--- a/feerci.pyx
+++ b/feerci.pyx
@@ -437,7 +437,7 @@ cpdef bootstrap_draw_sorted(np.ndarray[np.float64_t,ndim=1] a,int samples=-1):
         counts[i] = 0
     cdef np.ndarray[np.float64_t,ndim=1] out = np.zeros(samples)
     # Pick `sample` amount of indices
-    cdef np.ndarray[np.long_t,ndim=1] rands = np.random.randint(0,n_a,samples)
+    cdef np.ndarray[np.long,ndim=1] rands = np.random.randint(0,n_a,samples)
     # Loop over drawn rands array to fill index count histogram
     for i in range(samples):
         counts[rands[i]] += 1


### PR DESCRIPTION
Thanks for your tool!, here a quick PR to fix a recent Cython/Numpy compatibility change. (Numpy>=1.25.0)

https://github.com/numpy/numpy/pull/22637

Cython long_t and ulong_t removed

long_t and ulong_t were aliases for longlong_t and ulonglong_t and confusing (a remainder from of Python 2). This change may lead to the errors:

'long_t' is not a type identifier
'ulong_t' is not a type identifier

We recommend use of bit-sized types such as cnp.int64_t or the use of cnp.intp_t which is 32 bits on 32 bit systems and 64 bits on 64 bit systems (this is most compatible with indexing). If C long is desired, use plain long or npy_long. cnp.int_t is also long (NumPy’s default integer). However, long is 32 bit on 64 bit windows and we may wish to adjust this even in NumPy. (Please do not hesitate to contact NumPy developers if you are curious about this.)